### PR TITLE
Various features

### DIFF
--- a/compose/eos.py
+++ b/compose/eos.py
@@ -27,6 +27,11 @@ import os
 import sys
 import struct
 
+try:
+    from ._version import version
+except ImportError:
+    version = "unknown"
+
 class Metadata:
     """
     Class encoding the metadata/indexing used to read the EOS table
@@ -132,6 +137,9 @@ class Table:
         self.Y, self.A, self.Z = {}, {}, {}
         self.qK = {}
         self.lorene_cut = 0
+
+        self.version = version
+        self.git_hash = version.split("+g")[-1]
 
     def copy(self, copy_data=True):
         """
@@ -958,6 +966,8 @@ class Table:
             self.valid = self.valid & (self.thermo["cs2"] < 1)
 
     def _write_data(self, dfile, dtype):
+        dfile.attrs['version'] = self.version
+        dfile.attrs['git_hash'] = self.git_hash
         dfile.create_dataset("nb", dtype=dtype, data=self.nb,
             compression="gzip", compression_opts=9)
         dfile.create_dataset("t", dtype=dtype, data=self.t,

--- a/examples/SFHo.py
+++ b/examples/SFHo.py
@@ -57,6 +57,7 @@ eos.read(os.path.join(SCRIPTDIR, "SFHo"))
 
 # %%
 eos.compute_cs2(floor=1e-6)
+eos.compute_abar()
 eos.validate()
 # Remove the highest temperature point
 eos.restrict_idx(it1=-1)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup, Extension
 
 setup(
     name="PyCompOSE",
-    version="0.9",
+    setup_requires=["setuptools_scm"],
+    use_scm_version={"write_to": "compose/_version.py"},
     description="Read and manipulate equation of state tables in CompOSE ASCII format",
     url="https://github.com/computationalrelativity/PyCompOSE",
     package_dir={"compose": "compose", "compose.NQTLib": "compose/NQTs"},


### PR DESCRIPTION
## rns output
 add an ascii file in rns format. Logic copied from eos  scripts in THC.

## computing and adding Abar to the table
 Calculates and adds field "Abar" to the table based on Abar=1/sum(Y).

## init from pizza hydro.h5 and weak.h5
 This rescales chemical potentials and spec. internal energy to be consistent
 with the neutron mass as mass factor. I have compared the tables created from
 the Pizza SFHo tables to the SFHo from compose and found that, to get the
 baryon chemical potential correct, I need to use the atomic mass unit in the
 rescaling. Probably this was not correctly rescaled when the pizza tables where
 created from stellarcollapse.org tables. This is done with the `m_for_mub` 
 argument.

## automatic logic to determine a density index to cut the cold slice for the lorene output.
 As discussed with Peter, this calculates the index at which the pressure slope
 becomes small (dlogPdlogn < 0.5). If `find_lorene_rho_cut` is called before
 `write_lorene`, the lorene table will be cut at this density index. The
 cold_slice in the hdf5 includes this index as well, so that the coldeos in
 primitive_solver can read it and dump the same lorene file from the pgen.

## using setuptools_scm to automatically add git tag and hash to the hdf5
 This replaces the manual version in `setup.py` with a combination of git tag
 and hash and adds a `_version.py` to `compose/`. The version string is then 
 imported in `eos.py` and added to the hdf5 table.
