### PR TITLE
Fixed error (missing log) in function to add trapped nus

### DIFF
--- a/compose/eos.py
+++ b/compose/eos.py
@@ -1682,6 +1682,7 @@ class Table:
         T = self.t[np.newaxis, np.newaxis, :]
         iT = 1 / T
 
+        nb_down, nb_up = np.log10([nb_down, nb_up])
         sigmoid_factor = (
             smoothstep3(np.log10(self.nb), nb_down, nb_up)[:, np.newaxis, np.newaxis]
             * smoothstep3(self.t, T_down, T_up)[np.newaxis, np.newaxis, :]


### PR DESCRIPTION
Fix to the computation of the sigmoid factor that describes the transition to densities where trapped neutrinos contribute. The missing log meant that effectively the neutrino contribution was not applied to any density.