### PR TITLE
New trapped neutrinos code

### DIFF
--- a/compose/eos.py
+++ b/compose/eos.py
@@ -174,38 +174,35 @@ class Table:
 
         return eos
 
-    def copy_along_yq(self,yq_new):
+    def copy_along_yq(self, yq_new):
         """
         Clone 1-D or 2-D along new yq axis.
         """
 
-        assert self.shape[1]==1
+        assert self.shape[1] == 1
 
         eos_new = Table(self.md, self.dtype)
         eos_new.nb = self.nb.copy()
         eos_new.yq = yq_new
         eos_new.t = self.t.copy()
         eos_new.shape = (self.nb.shape[0], yq_new.shape[0], self.t.shape[0])
-        eos_new.valid = np.full(eos_new.shape,self.valid)
+        eos_new.valid = np.full(eos_new.shape, self.valid)
         eos_new.mn = self.mn
         eos_new.mp = self.mp
         eos_new.lepton = self.lepton
 
         for key, data in self.thermo.items():
-            eos_new.thermo[key] = np.full(eos_new.shape,data)
+            eos_new.thermo[key] = np.full(eos_new.shape, data)
         for key, data in self.Y.items():
-            eos_new.Y[key] = np.full(eos_new.shape,data)
+            eos_new.Y[key] = np.full(eos_new.shape, data)
         for key, data in self.A.items():
-            eos_new.A[key] = np.full(eos_new.shape,data)
+            eos_new.A[key] = np.full(eos_new.shape, data)
         for key, data in self.Z.items():
-            eos_new.Z[key] = np.full(eos_new.shape,data)
+            eos_new.Z[key] = np.full(eos_new.shape, data)
         for key, data in self.qK.items():
-            eos_new.qK[key] = np.full(eos_new.shape,data)
+            eos_new.qK[key] = np.full(eos_new.shape, data)
 
         return eos_new
-        
-
-
 
     def compute_cs2(self, floor=None):
         """
@@ -425,20 +422,21 @@ class Table:
         Wrapper around separate functions for different table dimensions.
         """
 
-        if(self.shape[0] > 1 and self.shape[1] > 1 and self.shape[2] > 1):
-            if not(nb_new):
+        if self.shape[0] > 1 and self.shape[1] > 1 and self.shape[2] > 1:
+            if not (nb_new):
                 nb_new = self.nb
-            if not(yq_new):
+            if not (yq_new):
                 yq_new = self.yq
-            if not(t_new):
+            if not (t_new):
                 t_new = self.t
 
             return self.interpolate_3D(nb_new, yq_new, t_new, method=method)
-        elif(self.shape[0] > 1 and self.shape[1] == 1 and self.shape[2] == 1):
+        elif self.shape[0] > 1 and self.shape[1] == 1 and self.shape[2] == 1:
             return self.interpolate_1D(nb_new, method="cubic")
         else:
-            raise ValueError("interpolation not implemented for current table dimensions.")
-
+            raise ValueError(
+                "interpolation not implemented for current table dimensions."
+            )
 
     def interpolate_3D(self, nb_new, yq_new, t_new, method="cubic"):
         """
@@ -506,7 +504,7 @@ class Table:
             eos.qK[key] = interp_var_to_grid(self.qK[key])
 
         return eos
-    
+
     def interpolate_1D(self, nb_new, method="cubic"):
         """
         Generate a new table by interpolating the EOS to the given grid
@@ -542,11 +540,10 @@ class Table:
 
         def interp_var_to_grid(var3d, log=False):
             if log:
-                myvar = np.log(var3d[:,0,0])
+                myvar = np.log(var3d[:, 0, 0])
             else:
-                myvar = var3d[:,0,0]
-            func = RegularGridInterpolator((log_nb,),
-                    myvar, method=method)
+                myvar = var3d[:, 0, 0]
+            func = RegularGridInterpolator((log_nb,), myvar, method=method)
             res = func(xi).reshape(eos.shape)
             if log:
                 return np.exp(res)
@@ -951,52 +948,87 @@ class Table:
 
         return eos_new
 
-    def enforce_pressure_density_monotonicity(self,logp=True,verb=0):
-        nb = self.nb[:,np.newaxis,np.newaxis]
-        p = self.thermo["Q1"]*nb
+    def enforce_pressure_density_monotonicity(self, logp=True, verb=0):
+        nb = self.nb[:, np.newaxis, np.newaxis]
+        p = self.thermo["Q1"] * nb
         if logp:
             p = np.log(p)
 
         eos_new = self.copy()
 
-        if verb>0: print(self.shape)
-        if verb>0: print(p.shape)
-        if verb>0: print(np.sum((p[:,:,1:] - p[:,:,:-1])<0.0))
-        if verb>0: print(np.sum((p[1:,:,:] - p[:-1,:,:])<0.0))
+        if verb > 0:
+            print(self.shape)
+        if verb > 0:
+            print(p.shape)
+        if verb > 0:
+            print(np.sum((p[:, :, 1:] - p[:, :, :-1]) < 0.0))
+        if verb > 0:
+            print(np.sum((p[1:, :, :] - p[:-1, :, :]) < 0.0))
 
         for yq_idx in range(self.shape[1]):
-            if verb>1: print(yq_idx,end="\r")
+            if verb > 1:
+                print(yq_idx, end="\r")
             for t_idx in range(self.shape[2]):
                 nb_idx = 0
-                while nb_idx < self.shape[0]-1:
+                while nb_idx < self.shape[0] - 1:
                     start_idx = nb_idx
-                    while p[nb_idx+1,yq_idx,t_idx]<=p[start_idx,yq_idx,t_idx]:
+                    while p[nb_idx + 1, yq_idx, t_idx] <= p[start_idx, yq_idx, t_idx]:
                         nb_idx += 1
                     end_idx = nb_idx + 1
 
-                    if end_idx>start_idx+1:
-                        if verb>2: print()
-                        while np.any((p[start_idx+1:end_idx+1,yq_idx,t_idx]-p[start_idx:end_idx,yq_idx,t_idx])<0):
-                            if verb>2: print(start_idx,end_idx,yq_idx,t_idx,p[start_idx,yq_idx,t_idx],p[end_idx,yq_idx,t_idx],np.min(p[start_idx+1:end_idx+1,yq_idx,t_idx]-p[start_idx:end_idx,yq_idx,t_idx]),end="\r")
-                            p[start_idx+1:end_idx,yq_idx,t_idx] = (p[start_idx:end_idx-1,yq_idx,t_idx] + p[start_idx+1:end_idx,yq_idx,t_idx] + p[start_idx+2:end_idx+1,yq_idx,t_idx])/3
-                        if verb>2: print()
+                    if end_idx > start_idx + 1:
+                        if verb > 2:
+                            print()
+                        while np.any(
+                            (
+                                p[start_idx + 1 : end_idx + 1, yq_idx, t_idx]
+                                - p[start_idx:end_idx, yq_idx, t_idx]
+                            )
+                            < 0
+                        ):
+                            if verb > 2:
+                                print(
+                                    start_idx,
+                                    end_idx,
+                                    yq_idx,
+                                    t_idx,
+                                    p[start_idx, yq_idx, t_idx],
+                                    p[end_idx, yq_idx, t_idx],
+                                    np.min(
+                                        p[start_idx + 1 : end_idx + 1, yq_idx, t_idx]
+                                        - p[start_idx:end_idx, yq_idx, t_idx]
+                                    ),
+                                    end="\r",
+                                )
+                            p[start_idx + 1 : end_idx, yq_idx, t_idx] = (
+                                p[start_idx : end_idx - 1, yq_idx, t_idx]
+                                + p[start_idx + 1 : end_idx, yq_idx, t_idx]
+                                + p[start_idx + 2 : end_idx + 1, yq_idx, t_idx]
+                            ) / 3
+                        if verb > 2:
+                            print()
                     nb_idx += 1
 
-        if verb>0: print(np.sum((p[:,:,1:] - p[:,:,:-1])<0.0))
-        if verb>0: print(np.sum((p[1:,:,:] - p[:-1,:,:])<0.0))
+        if verb > 0:
+            print(np.sum((p[:, :, 1:] - p[:, :, :-1]) < 0.0))
+        if verb > 0:
+            print(np.sum((p[1:, :, :] - p[:-1, :, :]) < 0.0))
 
         if logp:
             p = np.exp(p)
 
-        eos_new.thermo["Q1"] = p/nb
+        eos_new.thermo["Q1"] = p / nb
 
-        if verb>0: print(eos_new.shape)
-        if verb>0: print((p/nb).shape)
+        if verb > 0:
+            print(eos_new.shape)
+        if verb > 0:
+            print((p / nb).shape)
 
         return eos_new
 
-    def restrict(self, nb_min=None, nb_max=None, yq_min=None, yq_max=None,
-            t_min=None, t_max=None):
+    def restrict(
+        self, nb_min=None, nb_max=None, yq_min=None, yq_max=None, t_min=None, t_max=None
+    ):
         """
         Restrict the table in the given range
         """
@@ -1158,9 +1190,11 @@ class Table:
         eos.lepton = self.lepton
 
         for key, data in self.thermo.items():
-            if key=="cs2":
+            if key == "cs2":
                 continue
-            eos.thermo[key] = np.concatenate((new_thermo[key][:,np.newaxis,np.newaxis],data),axis=0)
+            eos.thermo[key] = np.concatenate(
+                (new_thermo[key][:, np.newaxis, np.newaxis], data), axis=0
+            )
         # for key, data in self.Y.items():
         #     eos.Y[key] = data.copy()
         # for key, data in self.A.items():
@@ -1180,12 +1214,14 @@ class Table:
 
         self.nb = np.loadtxt(os.path.join(path, "eos.nb"), skiprows=2, dtype=self.dtype)
         self.t = np.loadtxt(
-          os.path.join(path, "eos.t"), skiprows=2, dtype=self.dtype).reshape(-1)
+            os.path.join(path, "eos.t"), skiprows=2, dtype=self.dtype
+        ).reshape(-1)
         self.yq = np.loadtxt(
-          os.path.join(path, "eos.yq"), skiprows=2, dtype=self.dtype).reshape(-1)
+            os.path.join(path, "eos.yq"), skiprows=2, dtype=self.dtype
+        ).reshape(-1)
 
         ### some tables include 0-temperature slice at T index zero, this breaks log(T) interpolation, so we remove it here, but only if it is not the only T index
-        if self.t[0] == 0 and self.t.shape[0]>1:
+        if self.t[0] == 0 and self.t.shape[0] > 1:
             self.t = self.t[1:None]
 
         self.shape = (self.nb.shape[0], self.yq.shape[0], self.t.shape[0])
@@ -1203,10 +1239,9 @@ class Table:
                 )
             else:
                 self.nb = np.linspace(self.nb[0], self.nb[-1], self.nb.shape[0])
-            
-            
+
             ### skip this if there is only one yq
-            if self.shape[1]!=1:
+            if self.shape[1] != 1:
                 if yq_log:
                     self.yq = np.logspace(
                         np.log10(self.yq[0]),
@@ -1217,12 +1252,14 @@ class Table:
                 else:
                     self.yq = np.linspace(self.yq[0], self.yq[-1], self.yq.shape[0])
 
-            
             ### skip this if there is only one T
-            if self.shape[2]!=1:
+            if self.shape[2] != 1:
                 if t_log:
                     self.t = np.logspace(
-                        np.log10(self.t[0]), np.log10(self.t[-1]), self.t.shape[0], base=10
+                        np.log10(self.t[0]),
+                        np.log10(self.t[-1]),
+                        self.t.shape[0],
+                        base=10,
                     )
                 else:
                     self.t = np.linspace(self.t[0], self.t[-1], self.t.shape[0])
@@ -1242,20 +1279,20 @@ class Table:
 
     def __indicies_from_line(self, L):
         skip = False
-        it, inb, iyq = int(L[0])-1, int(L[1])-1, int(L[2])-1
+        it, inb, iyq = int(L[0]) - 1, int(L[1]) - 1, int(L[2]) - 1
 
         ### skip if T index is 0 (now -1), or adjust if 0 is the only T index.
-        if it==-1:
-            if self.shape[2]==1:
+        if it == -1:
+            if self.shape[2] == 1:
                 it = 0
             else:
-                skip=True
-        
+                skip = True
+
         ## sometimes the only yq index is 0 instead of 1 (the CompOSE documentation is agnostic towards this), adjust if necessary.
-        if iyq==-1:
-            assert self.shape[1]==0, "iyq=0 where indicies should start from 1"
-            iyq=0
-        
+        if iyq == -1:
+            assert self.shape[1] == 0, "iyq=0 where indicies should start from 1"
+            iyq = 0
+
         return it, inb, iyq, skip
 
     def __read_thermo_entries(self):
@@ -1270,8 +1307,9 @@ class Table:
             for line in tfile:
                 L = line.split()
                 it, inb, iyq, skip = self.__indicies_from_line(L)
-                if skip: continue
-                
+                if skip:
+                    continue
+
                 for iv in range(1, 8):
                     self.thermo[self.md.thermo[iv][0]][inb, iyq, it] = float(L[2 + iv])
                 Nadd = int(L[10])
@@ -1296,7 +1334,8 @@ class Table:
             for line in cfile:
                 L = line.split()
                 it, inb, iyq, skip = self.__indicies_from_line(L)
-                if skip: continue
+                if skip:
+                    continue
                 Nphase = int(L[3])
                 Npairs = int(L[4])
                 ix = 5
@@ -1332,7 +1371,8 @@ class Table:
             for line in cfile:
                 L = line.split()
                 it, inb, iyq, skip = self.__indicies_from_line(L)
-                if skip: continue
+                if skip:
+                    continue
                 Nmicro = int(L[3])
                 ix = 4
                 for im in range(Nmicro):
@@ -1353,89 +1393,92 @@ class Table:
         The specific internal energy and the chemical potentials are rescaled
         such that they are compatible to the neutron mass.
         """
-        with h5py.File(path, 'r') as hf:
-            sc = {key: np.array(hf[key][()]) for key in hf
-                     if isinstance(hf[key], h5py.Dataset) and hf[key].dtype.kind != 'V'}
+        with h5py.File(path, "r") as hf:
+            sc = {
+                key: np.array(hf[key][()])
+                for key in hf
+                if isinstance(hf[key], h5py.Dataset) and hf[key].dtype.kind != "V"
+            }
 
         for key, ar in sc.items():
             if not len(ar.shape) == 3:
                 continue
             sc[key] = np.transpose(ar, (2, 0, 1))
 
+        # mb = sc['mass_factor']
 
-        #mb = sc['mass_factor']
-
-        shift = sc['energy_shift']
+        shift = sc["energy_shift"]
 
         if mb is None:
-            UAMU_MEV      = 931.494061
-            mb = UAMU_MEV*(1.0 - shift/Table.unit_eps)
+            UAMU_MEV = 931.494061
+            mb = UAMU_MEV * (1.0 - shift / Table.unit_eps)
 
         self.mn = 939.56535
         self.mp = 938.27209
-        self.nb = 10**sc['logrho'] / Table.unit_dens/mb
-        self.t = 10**sc['logtemp']
-        self.yq = sc['ye']
+        self.nb = 10 ** sc["logrho"] / Table.unit_dens / mb
+        self.t = 10 ** sc["logtemp"]
+        self.yq = sc["ye"]
 
         self.shape = (self.nb.shape[0], self.yq.shape[0], self.t.shape[0])
         self.valid = np.ones(self.shape, dtype=bool)
         self.lepton = True
 
-        self.thermo["Q1"] = 10**sc['logpress'] / Table.unit_press / self.nb[:, None, None]
-        self.thermo["Q2"] = sc['entropy']
+        self.thermo["Q1"] = (
+            10 ** sc["logpress"] / Table.unit_press / self.nb[:, None, None]
+        )
+        self.thermo["Q2"] = sc["entropy"]
         mu_e = sc["mu_e"]
         mu_p = sc["mu_p"]
         mu_n = sc["mu_n"]
-        eps = 10**sc['logenergy'] / Table.unit_eps
+        eps = 10 ** sc["logenergy"] / Table.unit_eps
         eps -= shift / Table.unit_eps
         # transform to new mass factor
-        eps = (1+eps)*mb/self.mn - 1
+        eps = (1 + eps) * mb / self.mn - 1
         self.thermo["Q7"] = eps
-        temp_entr = self.t[None,  None, :]*self.thermo["Q2"]
-        self.thermo["Q6"] = eps - temp_entr/self.mn
+        temp_entr = self.t[None, None, :] * self.thermo["Q2"]
+        self.thermo["Q6"] = eps - temp_entr / self.mn
 
-        self.thermo["Q3"] = (mu_n + mb)/self.mn - 1
-        self.thermo["Q4"] = (mu_p - mu_n)/self.mn
-        self.thermo["Q5"] = (mu_e + mu_p - mu_n)/self.mn
+        self.thermo["Q3"] = (mu_n + mb) / self.mn - 1
+        self.thermo["Q4"] = (mu_p - mu_n) / self.mn
+        self.thermo["Q5"] = (mu_e + mu_p - mu_n) / self.mn
 
-        self.Y["e"] = np.meshgrid(self.nb, self.yq, self.t, indexing='ij')[1]
-        self.Y["n"] = sc['Xn']
-        self.Y["p"] = sc['Xp']
-        self.Y["He4"] = sc['Xa']/4
+        self.Y["e"] = np.meshgrid(self.nb, self.yq, self.t, indexing="ij")[1]
+        self.Y["n"] = sc["Xn"]
+        self.Y["p"] = sc["Xp"]
+        self.Y["He4"] = sc["Xa"] / 4
 
         if "Xl" in sc.keys():
             if "Xl" not in self.md.quads.values():
-                Yl = sc["Xl"]/sc["Albar"]
-                Yh = sc["Xh"]/sc["Abar"]
-                Xh = sc["Xh"]+sc["Xl"]
+                Yl = sc["Xl"] / sc["Albar"]
+                Yh = sc["Xh"] / sc["Abar"]
+                Xh = sc["Xh"] + sc["Xl"]
                 Yh[mask := Xh <= 0] = 1
                 Yl[mask] = 1
-                Abar = Xh/(Yh+Yl)
+                Abar = Xh / (Yh + Yl)
                 Abar[mask] = 1
-                Zbar = (Yh*sc["Zbar"] + Yl*sc["Zlbar"])/(Yh+Yl)
-                self.Y["N"] = Xh/Abar
+                Zbar = (Yh * sc["Zbar"] + Yl * sc["Zlbar"]) / (Yh + Yl)
+                self.Y["N"] = Xh / Abar
                 self.Y["N"][~np.isfinite(self.Y["N"])] = 0
                 self.A["N"] = Abar
                 self.Z["N"] = Zbar
             else:
-                self.Y["N"] = sc["X"]/sc["Abar"]
+                self.Y["N"] = sc["X"] / sc["Abar"]
                 self.Y["N"][~np.isfinite(self.Y["N"])] = 0
                 self.A["N"] = sc["Abar"]
                 self.Z["N"] = sc["Zbar"]
-                self.Y["Nl"] = sc["Xl"]/sc["Albar"]
+                self.Y["Nl"] = sc["Xl"] / sc["Albar"]
                 self.Y["Nl"][~np.isfinite(self.Y["Nl"])] = 0
                 self.A["Nl"] = sc["Albar"]
                 self.Z["Nl"] = sc["Zlbar"]
         else:
-            self.Y["N"] = sc["Xh"]/sc["Abar"]
+            self.Y["N"] = sc["Xh"] / sc["Abar"]
             self.Y["N"][~np.isfinite(self.Y["N"])] = 0
             self.A["N"] = sc["Abar"]
             self.Z["N"] = sc["Zbar"]
 
         for name, _ in self.md.pairs.values():
             if name not in self.Y:
-                self.Y[name] = np.zeros_like(self.Y['e'])
-
+                self.Y[name] = np.zeros_like(self.Y["e"])
 
     def read_from_pizza(
         self,
@@ -1864,7 +1907,7 @@ class Table:
 
         with open(fname, "w") as f:
             f.write("#\n#\n#\n#\n#\n%d\n#\n#\n#\n" % (len(self.nb) - self.lorene_cut))
-            for ind, i in enumerate(range(self.lorene_cut, len(self.nb),subsample)):
+            for ind, i in enumerate(range(self.lorene_cut, len(self.nb), subsample)):
                 nb = self.nb[i]
                 e = (
                     Table.unit_dens
@@ -1900,8 +1943,8 @@ class Table:
         h_CGS = Table.unit_eps * h
 
         if truncate:
-             h_CGS[0] = 1 # Exact value = 0, but RNS seems to require that.
-             p_CGS[0] = 1
+            h_CGS[0] = 1  # Exact value = 0, but RNS seems to require that.
+            p_CGS[0] = 1
 
         with open(fname, "w") as f:
             f.write(f"{len(tmd_CGS):d} \n")
@@ -1929,9 +1972,9 @@ class Table:
         """
         assert overwrite or (not "e" in self.Y.keys())
 
-        self.Y["e"] = self.yq[np.newaxis,:,np.newaxis]*np.ones(self.shape)
+        self.Y["e"] = self.yq[np.newaxis, :, np.newaxis] * np.ones(self.shape)
 
-    def enfoce_positive_Q1(self,Q1_min=1e-16,P_min=None):
+    def enfoce_positive_Q1(self, Q1_min=1e-16, P_min=None):
         """
         Enforce positivity of Q1.
 
@@ -1939,10 +1982,10 @@ class Table:
         """
 
         if P_min:
-            P = self.thermo["Q1"]*self.nb[:,np.newaxis,np.newaxis]
-            P = np.clip(P,P_min,None)
-            self.thermo["Q1"] = P/self.nb[:,np.newaxis,np.newaxis]
-        
+            P = self.thermo["Q1"] * self.nb[:, np.newaxis, np.newaxis]
+            P = np.clip(P, P_min, None)
+            self.thermo["Q1"] = P / self.nb[:, np.newaxis, np.newaxis]
+
         else:
             self.thermo["Q1"] = np.clip(self.thermo["Q1"], Q1_min, None)
 
@@ -1970,15 +2013,23 @@ class Table:
                     f.write(" %.15e" % yi)
                 f.write("\n")
 
-    def add_trapped_neutrinos(
+    def add_equilibrium_neutrinos(
         self, nb_down=7.5163e-04, nb_up=4.7425e-03, T_down=2, T_up=4
     ):
         """
-        Add the contribution of trapped neutrinos (each flavor modeled as an
-        ultrarelativistic Fermi gas) to the EOS (i.e. to Q1, Q2, Q6, and Q7).
-        The contribution of the neutrinos is confined to high densities and
-        temperatures by multiplying it by a sigmoid factor that transitions
-        between 0 and 1 in user-defined intervals of nb and T.
+        Add the contribution of neutrinos in equilibrium with
+        baryons/leptons/photons (each flavor modeled as an
+        ultrarelativistic Fermi gas) to the EOS (i.e. to Q1, Q2, Q6, and
+        Q7). The contribution of the neutrinos is confined to high
+        densities and temperatures by multiplying it by a sigmoid factor
+        that transitions between 0 and 1 in user-defined intervals of nb
+        and T.
+
+        Note: this function takes the temperature of the fluid as given
+        and assumes that the table's Yq is actually Ye, and proceeds to
+        evaluate the electron neutrino chemical potentials accordingly.
+        This may not be what one wants. See the method
+        'add_trapped_neutrinos' for a comparison.
 
         Note: at present muon and tau neutrinos are treated as having zero
         chemical potential. If information about the chemical potential of
@@ -2077,3 +2128,175 @@ class Table:
 
         self.thermo["Q6"] += Q6_nu_tot * sigmoid_factor
 
+    def add_trapped_neutrinos(
+        self, nb_down=7.5163e-04, nb_up=4.7425e-03, T_down=2, T_up=4
+    ):
+        """
+        Add the contribution of trapped neutrinos conserving the leptonic
+        fracion Yl (or charge fraction Yq). The contribution of the neutrinos is confined to high
+        densities and temperatures by multiplying it by a sigmoid factor
+        that transitions between 0 and 1 in user-defined intervals of nb and T.
+
+        Conserving the charge fraction means that it solves the equation:
+
+        Ye + Y_nue(nb, Ye, T) - Y_anue(nb, Ye, T) - Yq = 0
+
+        for the electron fraction Ye, getting the Yq from the table. Y_nue and
+        Y_anue are modelled as an ultrarelativistic Fermi gas (see the method
+        'add_equilibrium_neutrinos').
+
+        Note: at the moment the function is hard coded to use piecewise linear
+        interpolation.
+
+        Keyword arguments:
+        nb_down -- start of transition in number density (float, default: 7.5163e-04 fm^-3 (~1e12.1 g/cm^3))
+        nb_up   -- end of transition in number density (float, default: 4.7425e-03 fm^-3 (~1e12.9 g/cm^3))
+        T_up    -- start of transition in temperature (float, default: 2 MeV)
+        T_down  -- end of transition in temperature (float, default: 4 MeV)
+        """
+
+        from scipy.optimize import bisect
+        from .utils import smoothstep3
+
+        # This is 4 pi / (hc)^3 in units of (MeV fm)^-3
+        K = 6.593421629164754e-09
+        oneThird = 1.0 / 3.0
+        piSquared = np.pi**2
+
+        # Inverse of the grid step of the Yq-axis.
+        inv_delta_yq = 1.0 / (self.yq[1] - self.yq[0])
+
+        # 3D tables of relativistic chemical potentials [MeV]
+        mu_n_table = (self.thermo["Q3"] + 1.0) * self.mn
+        mu_p_table = (self.thermo["Q3"] + self.thermo["Q4"] + 1.0) * self.mn
+        mu_e_table = (self.thermo["Q5"] - self.thermo["Q4"]) * self.mn
+
+        # Initialize 3D grid of Ye with shape (nb, yq, T)
+        Ye_grid = np.zeros((len(self.nb), len(self.yq), len(self.t)))
+
+        # Progress bar
+        total = len(self.nb) * len(self.yq) * len(self.t)
+
+        # ================================================ #
+        # === Step 1: Compute Ye for fixed (nb, Yq, T) === #
+        # ================================================ #
+
+        for i, nb_val in enumerate(self.nb):
+
+            sigmoid_nb = smoothstep3(
+                np.log10(nb_val), np.log10(nb_down), np.log10(nb_up)
+            )
+
+            # If sigmoid_nb == 0, we skip the entire loop, since Yq == Ye
+            if sigmoid_nb == 0:
+                continue
+
+            inv_nb = 1.0 / nb_val  # [fm^3]
+
+            for k, T_val in enumerate(self.t):
+
+                sigmoid_T = smoothstep3(T_val, T_down, T_up)
+
+                # If sigmoid_T == 0, we skip the entire loop, since Yq == Ye
+                if sigmoid_T == 0:
+                    continue
+
+                # Full sigmoid factor
+                sigmoid_factor = sigmoid_nb * sigmoid_T
+
+                inv_T = 1.0 / T_val  # [MeV^-1]
+                T_cube = T_val**3  # [MeV^3]
+
+                C = K * inv_nb * T_cube * sigmoid_factor  # [dimensionless]
+
+                yq_min = self.yq[0]
+                yq_max = self.yq[-1]
+
+                for j, Yq_val in enumerate(self.yq):
+
+                    def f_root(Ye):
+                        """
+                        Function to solve for Ye
+                        """
+
+                        # Clip Ye to be inside the table.
+                        # Avoids "out of bounds" exception inside chemical
+                        # potentials interpolations
+                        Ye = np.clip(Ye, yq_min, yq_max)
+
+                        # Find index for interpolating Ye over Yq
+                        idx = int((Ye - yq_min) * inv_delta_yq)
+                        idx = idx - 1 if idx == len(self.yq) - 1 else idx
+                        assert idx >= 0
+                        assert idx <= len(self.yq) - 1
+
+                        # Linear interpolation coefficient
+                        h = (Ye - self.yq[idx]) * inv_delta_yq
+
+                        # Interpolate chemical potentials at (nb, Ye_eq, T)
+                        mu_e = (
+                            mu_e_table[i, idx, k] * (1 - h)
+                            + mu_e_table[i, idx + 1, k] * h
+                        )
+                        mu_n = (
+                            mu_n_table[i, idx, k] * (1 - h)
+                            + mu_n_table[i, idx + 1, k] * h
+                        )
+                        mu_p = (
+                            mu_p_table[i, idx, k] * (1 - h)
+                            + mu_p_table[i, idx + 1, k] * h
+                        )
+
+                        # Electron neutrino degeneracy parameter
+                        eta_nue = (mu_e + mu_p - mu_n) * inv_T
+
+                        # Function value. Note that Ynue - Yanue reduces to a
+                        # simple polynomial in eta_nue due to the properties of
+                        # the integer-order Fermi-Dirac integrals.
+                        f = (
+                            Ye
+                            - Yq_val
+                            + C * eta_nue * (eta_nue**2 + piSquared) * oneThird
+                        )
+
+                        return f
+
+                    try:
+
+                        # Solve for Ye
+                        Ye_grid[i, j, k] = bisect(
+                            f_root, yq_min, yq_max, xtol=1e-6, rtol=1e-6
+                        )
+
+                        # Clip on the Ye found to avoid "out of bounds"
+                        # exception in the 1D interpolation below.
+                        Ye_grid[i, j, k] = np.clip(Ye_grid[i, j, k], yq_min, yq_max)
+
+                    except Exception as e:
+                        print(e)
+
+                    # ========================================================= #
+                    # === Step 2: Interpolate self.thermo Qs in (nb, Ye, T) === #
+                    # ========================================================= #
+
+                    # Interpolation index
+                    idx = int((Ye_grid[i, j, k] - yq_min) * inv_delta_yq)
+                    assert idx >= 0
+                    assert idx <= len(self.yq) - 1
+
+                    # Linear interpolation coefficient
+                    h = (Ye_grid[i, j, k] - self.yq[idx]) * inv_delta_yq
+
+                    # 1D interpolations along Yq-axis at Ye, for every quantity
+                    for key in self.thermo:
+
+                        self.thermo[key][i, j, k] = (
+                            self.thermo[key][i, idx, k] * (1 - h)
+                            + self.thermo[key][i, idx + 1, k] * h
+                        )
+
+        # =========================================================== #
+        # === Step 3: Add equilibrium neutrinos to the updated Qs === #
+        # =========================================================== #
+
+        self.add_equilibrium_neutrinos(nb_down, nb_up, T_down, T_up)

--- a/compose/multitable.py
+++ b/compose/multitable.py
@@ -1,4 +1,3 @@
-
 import sys
 import struct
 import numpy as np
@@ -9,6 +8,7 @@ try:
 except ImportError:
     version = "unknown"
 
+
 class MultiTable:
     def __init__(self, dtype=np.float64):
         """
@@ -17,7 +17,7 @@ class MultiTable:
         * dtype : data type
         """
         self.dtype = dtype
-        
+
         self.table_3D_names = []
         self.table_2D_names = []
 
@@ -29,20 +29,29 @@ class MultiTable:
 
         self.nscalars = 0
 
-    def set_scalar_weights(self,nscalars,Y_weights,N_weights):
-        assert np.issubdtype(Y_weights.dtype, np.integer), "Y_weights must have integer type, found: "+str(Y_weights.dtype)
-        assert np.issubdtype(N_weights.dtype, np.integer), "N_weights must have integer type, found: "+str(N_weights.dtype)
+    def set_scalar_weights(self, nscalars, Y_weights, N_weights):
+        assert np.issubdtype(
+            Y_weights.dtype, np.integer
+        ), "Y_weights must have integer type, found: " + str(Y_weights.dtype)
+        assert np.issubdtype(
+            N_weights.dtype, np.integer
+        ), "N_weights must have integer type, found: " + str(N_weights.dtype)
 
         self.nscalars = nscalars
 
         ntables_3D = len(self.tables_3D)
         ntables_2D = len(self.tables_2D)
 
-        if Y_weights.shape != (ntables_3D,nscalars+1):
-            print("Y_weights does not match expected shape: ",(ntables_3D,nscalars+1))
-        
-        if N_weights.shape != (ntables_3D+ntables_2D,nscalars+1):
-            print("N_weights does not match expected shape: ",(ntables_3D+ntables_2D,nscalars+1))
+        if Y_weights.shape != (ntables_3D, nscalars + 1):
+            print(
+                "Y_weights does not match expected shape: ", (ntables_3D, nscalars + 1)
+            )
+
+        if N_weights.shape != (ntables_3D + ntables_2D, nscalars + 1):
+            print(
+                "N_weights does not match expected shape: ",
+                (ntables_3D + ntables_2D, nscalars + 1),
+            )
 
         self.Y_weights = Y_weights
         self.N_weights = N_weights
@@ -51,29 +60,35 @@ class MultiTable:
         new_table = Table(metadata=metadata, dtype=self.dtype)
         self.table_3D_names.append(name)
 
-        if dims==3:
+        if dims == 3:
             self.tables_3D[name] = new_table
         else:
-            assert dims==3, "Only 3D CompOSE tables are currently implemented for MultiTable"
-        
+            assert (
+                dims == 3
+            ), "Only 3D CompOSE tables are currently implemented for MultiTable"
+
         return
-    
+
     def init_MuEOS_table(self, name, dims=2):
         new_table = MuEOSTable(dtype=self.dtype)
         self.table_2D_names.append(name)
 
-        if dims==2:
+        if dims == 2:
             self.tables_2D[name] = new_table
         else:
-            assert dims==2, "Only 2D MuEOS tables are currently implemented for MultiTable"
-    
+            assert (
+                dims == 2
+            ), "Only 2D MuEOS tables are currently implemented for MultiTable"
+
         return
-    
+
     def calc_CompOSE_values(self, table):
         p = table.thermo["Q1"] * table.nb[:, np.newaxis, np.newaxis]
-        s = table.thermo["Q2"] * table.nb[:, np.newaxis, np.newaxis] # This is entropy density (per volume) not entropy per baryon as in above cs2 calculation
-        mub = table.thermo["Q3"]*table.mn
-        muq = table.thermo["Q4"]*table.mn
+        s = (
+            table.thermo["Q2"] * table.nb[:, np.newaxis, np.newaxis]
+        )  # This is entropy density (per volume) not entropy per baryon as in above cs2 calculation
+        mub = table.thermo["Q3"] * table.mn
+        muq = table.thermo["Q4"] * table.mn
         u = table.mn * (table.thermo["Q7"] + 1) * table.nb[:, np.newaxis, np.newaxis]
 
         if p.min() <= 0.0:
@@ -113,60 +128,89 @@ class MultiTable:
 
         h_min = np.min(table.pressure + table.energy)
 
-        data_dict = {"scalars" : [("dims", 3, "{:d}"),
-                                  ("h_min", h_min, "{:21.16e}")], # (name, value, format string)
-                     "points"  : [("ni", len(table.nb)),
-                                  ("yi", len(table.yq)),
-                                  ("t", len(table.t))], # (name, count)
-                     "fields"  : ["pressure","energy","entropy",
-                                  "dpdn","dpdt","dsdn","dsdt"], # (name)
-                     "data"    : {"ni" : table.nb,
-                                  "yi"  : table.yq,
-                                  "t"  : table.t,
-                                  "pressure" : table.pressure,
-                                  "energy"   : table.energy,
-                                  "entropy"  : table.entropy,
-                                  "dpdn" : table.dpdn,
-                                  "dpdt" : table.dpdt,
-                                  "dsdn" : table.dsdn,
-                                  "dsdt" : table.dsdt}} # values for points and fields
+        data_dict = {
+            "scalars": [
+                ("dims", 3, "{:d}"),
+                ("h_min", h_min, "{:21.16e}"),
+            ],  # (name, value, format string)
+            "points": [
+                ("ni", len(table.nb)),
+                ("yi", len(table.yq)),
+                ("t", len(table.t)),
+            ],  # (name, count)
+            "fields": [
+                "pressure",
+                "energy",
+                "entropy",
+                "dpdn",
+                "dpdt",
+                "dsdn",
+                "dsdt",
+            ],  # (name)
+            "data": {
+                "ni": table.nb,
+                "yi": table.yq,
+                "t": table.t,
+                "pressure": table.pressure,
+                "energy": table.energy,
+                "entropy": table.entropy,
+                "dpdn": table.dpdn,
+                "dpdt": table.dpdt,
+                "dsdn": table.dsdn,
+                "dsdt": table.dsdt,
+            },
+        }  # values for points and fields
 
         self.write_athtab_file(fname, data_dict)
         return
-    
+
     def make_athtab_2D(self, name, fname):
         table = self.tables_2D[name]
 
         h_min = np.min(table.pressure + table.energy)
 
-        data_dict = {"scalars" : [("dims", 2, "{:d}"),
-                                  ("h_min", h_min, "{:21.16e}")], # (name, value, format string)
-                     "points"  : [("ni", len(table.n)),
-                                  ("t", len(table.t))], # (name, count)
-                     "fields"  : ["pressure","energy","entropy",
-                                  "dpdn","dpdt","dsdn","dsdt"], # (name)
-                     "data"    : {"ni" : table.n,
-                                  "t"  : table.t,
-                                  "pressure" : table.pressure,
-                                  "energy"   : table.energy,
-                                  "entropy"  : table.entropy,
-                                  "dpdn" : table.dpdn,
-                                  "dpdt" : table.dpdt,
-                                  "dsdn" : table.dsdn,
-                                  "dsdt" : table.dsdt}} # values for points and fields
- 
-        self.write_athtab_file(fname, data_dict)
-        return
-    
-    def make_athtab_T_union(self, T_union, fname):
-        data_dict = {"scalars" : [("dims",1,"{:d}")], # (name, value, format string)
-                     "points"  : [("t",len(T_union))], # (name, count)
-                     "fields"  : [], # (name)
-                     "data"    : {"t" : T_union}} # values for points and fields
+        data_dict = {
+            "scalars": [
+                ("dims", 2, "{:d}"),
+                ("h_min", h_min, "{:21.16e}"),
+            ],  # (name, value, format string)
+            "points": [("ni", len(table.n)), ("t", len(table.t))],  # (name, count)
+            "fields": [
+                "pressure",
+                "energy",
+                "entropy",
+                "dpdn",
+                "dpdt",
+                "dsdn",
+                "dsdt",
+            ],  # (name)
+            "data": {
+                "ni": table.n,
+                "t": table.t,
+                "pressure": table.pressure,
+                "energy": table.energy,
+                "entropy": table.entropy,
+                "dpdn": table.dpdn,
+                "dpdt": table.dpdt,
+                "dsdn": table.dsdn,
+                "dsdt": table.dsdt,
+            },
+        }  # values for points and fields
 
         self.write_athtab_file(fname, data_dict)
         return
-    
+
+    def make_athtab_T_union(self, T_union, fname):
+        data_dict = {
+            "scalars": [("dims", 1, "{:d}")],  # (name, value, format string)
+            "points": [("t", len(T_union))],  # (name, count)
+            "fields": [],  # (name)
+            "data": {"t": T_union},
+        }  # values for points and fields
+
+        self.write_athtab_file(fname, data_dict)
+        return
+
     def write_athtab_file(self, fname, data_dict, dtype=np.float64, endian="native"):
         """
         Writes the table as a .athtab file for use in AthenaK
@@ -236,26 +280,30 @@ class MultiTable:
             for field_name in field_list:
                 data_current = data_dict["data"][field_name]
                 data_size = data_current.size
-                f.write(struct.pack(f"{endianness}{data_size}{fspec}", *data_current.flatten()))
-        
+                f.write(
+                    struct.pack(
+                        f"{endianness}{data_size}{fspec}", *data_current.flatten()
+                    )
+                )
+
         return
 
     def write_athtab(self, output_dir, fnames={}, dtype=np.float64, endian="native"):
         n_ni_count = 0
         n_yi_count = 0
-        n_T_count  = 0
+        n_T_count = 0
         n_table_count = 0
 
-        nvars = 7 # press, energy, entropy, dpdn, dpdt, dsdn, dsdt
+        nvars = 7  # press, energy, entropy, dpdn, dpdt, dsdn, dsdt
 
         t_union = []
 
         min_n = -np.inf
-        max_n =  np.inf
+        max_n = np.inf
         min_T = -np.inf
-        max_T =  np.inf
-        min_Y =  np.full((self.nscalars,),-np.inf)
-        max_Y =  np.full((self.nscalars,), np.inf)
+        max_T = np.inf
+        min_Y = np.full((self.nscalars,), -np.inf)
+        max_Y = np.full((self.nscalars,), np.inf)
 
         table_3D_output_fnames = []
         table_2D_output_fnames = []
@@ -269,26 +317,34 @@ class MultiTable:
             mb = self.tables_3D[name].mn
             ni_count_current = self.tables_3D[name].nb.shape[0]
             yi_count_current = self.tables_3D[name].yq.shape[0]
-            T_count_current  = self.tables_3D[name].t.shape[0]
+            T_count_current = self.tables_3D[name].t.shape[0]
             for t in self.tables_3D[name].t:
                 t_union.append(t)
-            
+
             table_3D_output_fnames.append(fname_current)
             self.make_athtab_3D(name, output_dir + fname_current)
-            
+
             min_n = max(min_n, self.tables_3D[name].nb[0])
             max_n = min(max_n, self.tables_3D[name].nb[-1])
             min_T = max(min_T, self.tables_3D[name].t[0])
             max_T = min(max_T, self.tables_3D[name].t[-1])
             for Y_idx in range(self.nscalars):
-                min_Y[Y_idx] = max(self.tables_3D[name].yq[0]/self.Y_weights[table_idx,Y_idx+1],min_Y[Y_idx])
+                min_Y[Y_idx] = max(
+                    self.tables_3D[name].yq[0] / self.Y_weights[table_idx, Y_idx + 1],
+                    min_Y[Y_idx],
+                )
             for Y_idx in range(self.nscalars):
-                max_Y[Y_idx] = min(self.tables_3D[name].yq[-1]/self.Y_weights[table_idx,Y_idx+1],max_Y[Y_idx])
-            
+                max_Y[Y_idx] = min(
+                    self.tables_3D[name].yq[-1] / self.Y_weights[table_idx, Y_idx + 1],
+                    max_Y[Y_idx],
+                )
+
             n_ni_count += ni_count_current
             n_yi_count += yi_count_current
-            n_T_count  += T_count_current
-            n_table_count += ni_count_current*yi_count_current*T_count_current*nvars
+            n_T_count += T_count_current
+            n_table_count += (
+                ni_count_current * yi_count_current * T_count_current * nvars
+            )
 
         n_tables_3D = len(table_3D_output_fnames)
 
@@ -297,26 +353,26 @@ class MultiTable:
                 fname_current = fnames[name]
             else:
                 fname_current = name + ".athtab"
-    
+
             ni_count_current = self.tables_2D[name].n.shape[0]
-            T_count_current  = self.tables_2D[name].t.shape[0]
+            T_count_current = self.tables_2D[name].t.shape[0]
             for t in self.tables_2D[name].t:
                 t_union.append(t)
-                
+
             table_2D_output_fnames.append(fname_current)
             self.make_athtab_2D(name, output_dir + fname_current)
-            
+
             min_T = max(min_T, self.tables_2D[name].t[0])
             max_T = min(max_T, self.tables_2D[name].t[-1])
-            
+
             n_ni_count += ni_count_current
-            n_T_count  += T_count_current
-            n_table_count += ni_count_current*T_count_current*nvars
+            n_T_count += T_count_current
+            n_table_count += ni_count_current * T_count_current * nvars
 
         n_tables_2D = len(table_2D_output_fnames)
 
         t_union = np.sort(np.unique(np.array(t_union)))
-        t_union = t_union[np.logical_and(t_union>=min_T,t_union<=max_T)]
+        t_union = t_union[np.logical_and(t_union >= min_T, t_union <= max_T)]
         n_tunion = t_union.shape[0]
 
         if "T_union" in fnames.keys():
@@ -333,16 +389,16 @@ class MultiTable:
 
         with open(output_dir + fname_header, "w") as file_header:
             file_header.write("# MultiTable header file\n")
-            
+
             file_header.write("# Number of each type of subtable\n")
             file_header.write("n_3D_tables = {:d}\n".format(n_tables_3D))
             file_header.write("n_2D_tables = {:d}\n".format(n_tables_2D))
             file_header.write("\n")
-            
+
             file_header.write("# Number of species fractions to be used\n")
             file_header.write("n_species = {:d}\n".format(self.nscalars))
             file_header.write("\n")
-            
+
             file_header.write("# Total storage required for subtables\n")
             file_header.write("n_ni    = {:d}\n".format(n_ni_count))
             file_header.write("n_yi    = {:d}\n".format(n_yi_count))
@@ -350,7 +406,7 @@ class MultiTable:
             file_header.write("n_T_union = {:d}\n".format(n_tunion))
             file_header.write("n_table = {:d}\n".format(n_table_count))
             file_header.write("\n")
-            
+
             file_header.write("# Scalar values\n")
             file_header.write("mb = {:21.16e}\n".format(mb))
             file_header.write("min_n = {:21.16e}\n".format(min_n))
@@ -358,41 +414,54 @@ class MultiTable:
             file_header.write("min_T = {:21.16e}\n".format(min_T))
             file_header.write("max_T = {:21.16e}\n".format(max_T))
             for idx in range(self.nscalars):
-                file_header.write("min_Y[{:d}] = {:21.16e}\n".format(idx,min_Y[idx]))
-                file_header.write("max_Y[{:d}] = {:21.16e}\n".format(idx,max_Y[idx]))
+                file_header.write("min_Y[{:d}] = {:21.16e}\n".format(idx, min_Y[idx]))
+                file_header.write("max_Y[{:d}] = {:21.16e}\n".format(idx, max_Y[idx]))
             file_header.write("\n")
-            
+
             file_header.write("# 3D table relative locations (n_3D_tables)\n")
             for table_idx, table_fname in enumerate(table_3D_output_fnames):
-                file_header.write("table_3D_{:d} = ./{:s}\n".format(table_idx, table_fname))
+                file_header.write(
+                    "table_3D_{:d} = ./{:s}\n".format(table_idx, table_fname)
+                )
             file_header.write("\n")
-            
+
             file_header.write("# 2D table relative locations (n_2D_tables)\n")
             for table_idx, table_fname in enumerate(table_2D_output_fnames):
-                file_header.write("table_2D_{:d} = ./{:s}\n".format(table_idx, table_fname))
+                file_header.write(
+                    "table_2D_{:d} = ./{:s}\n".format(table_idx, table_fname)
+                )
             file_header.write("\n")
-            
+
             file_header.write("# Union of temperatures table relative location\n")
             file_header.write("T_union = ./{:s}\n".format(fname_T_union))
             file_header.write("\n")
-            
+
             file_header.write("# Y weights (n_3D_tables, 1+n_species)\n")
             for idx in range(n_tables_3D):
-                for jdx in range(self.nscalars+1):
-                    file_header.write(("wY_({:d},{:d}) = {:d}\n").format(idx,jdx,self.Y_weights[idx,jdx]))
+                for jdx in range(self.nscalars + 1):
+                    file_header.write(
+                        ("wY_({:d},{:d}) = {:d}\n").format(
+                            idx, jdx, self.Y_weights[idx, jdx]
+                        )
+                    )
             file_header.write("\n")
-            
+
             file_header.write("# N weights (n_3D_tables+n_tables_2D, 1+n_species)\n")
             for idx in range(n_tables_3D + n_tables_2D):
-                for jdx in range(self.nscalars+1):
-                    file_header.write(("wN_({:d},{:d}) = {:d}\n").format(idx,jdx,self.N_weights[idx,jdx]))
+                for jdx in range(self.nscalars + 1):
+                    file_header.write(
+                        ("wN_({:d},{:d}) = {:d}\n").format(
+                            idx, jdx, self.N_weights[idx, jdx]
+                        )
+                    )
             file_header.write("\n")
 
         return
 
+
 class MuEOSTable:
     def __init__(self, dtype=np.float64):
-        self.dtype=dtype
+        self.dtype = dtype
 
         self.n = np.empty(0)
         self.t = np.empty(0)
@@ -408,32 +477,36 @@ class MuEOSTable:
 
         # Data to be loaded from file
         dataset_dict = {
-            0:  "nl",     # Number density of leptons
-            1:  "nl_bar", # Number density of anti-leptons
-            2:  "pl",     # Pressure of leptons
-            3:  "pl_bar", # Pressure of anti-leptons
-            4:  "el",     # Internal energy density of leptons
-            5:  "el_bar", # Internal energy density of anti-leptons
-            6:  "sl",     # Entropy density of leptons
-            7:  "sl_bar", # Entropy density of anti-leptons
-            8:  "mul",    # Chemical potential of leptons
-            9:  "dpdn",   # Derivative of pressure wrt lepton number density
-            10: "dsdn",   # Derivative of entropy density wrt lepton number density
-            11: "dpdt",   # Derivative of pressure wrt temperature
-            12: "dsdt",   # Derivative of entropy density wrt temperature
-            }
+            0: "nl",  # Number density of leptons
+            1: "nl_bar",  # Number density of anti-leptons
+            2: "pl",  # Pressure of leptons
+            3: "pl_bar",  # Pressure of anti-leptons
+            4: "el",  # Internal energy density of leptons
+            5: "el_bar",  # Internal energy density of anti-leptons
+            6: "sl",  # Entropy density of leptons
+            7: "sl_bar",  # Entropy density of anti-leptons
+            8: "mul",  # Chemical potential of leptons
+            9: "dpdn",  # Derivative of pressure wrt lepton number density
+            10: "dsdn",  # Derivative of entropy density wrt lepton number density
+            11: "dpdt",  # Derivative of pressure wrt temperature
+            12: "dsdt",  # Derivative of entropy density wrt temperature
+        }
         num_vars = 13
-        
+
         # Load table header
         table_header = np.loadtxt(path_to_table, dtype=int, max_rows=2, ndmin=1)
         num_nl = table_header[0]
         num_t = table_header[1]
 
-        log_nl = np.loadtxt(path_to_table,dtype=self.dtype,skiprows=2,max_rows=1,ndmin=1)
-        log_t  = np.loadtxt(path_to_table,dtype=self.dtype,skiprows=3,max_rows=1,ndmin=1)
+        log_nl = np.loadtxt(
+            path_to_table, dtype=self.dtype, skiprows=2, max_rows=1, ndmin=1
+        )
+        log_t = np.loadtxt(
+            path_to_table, dtype=self.dtype, skiprows=3, max_rows=1, ndmin=1
+        )
 
-        assert(log_nl.shape[0]==num_nl)
-        assert(log_t.shape[0]==num_t)
+        assert log_nl.shape[0] == num_nl
+        assert log_t.shape[0] == num_t
 
         self.n = 10.0**log_nl
         self.t = 10.0**log_t
@@ -442,13 +515,15 @@ class MuEOSTable:
 
         data_raw = np.loadtxt(path_to_table, dtype=self.dtype, skiprows=4, ndmin=2)
 
-        assert data_raw.shape == (num_vars*num_nl,num_t)
+        assert data_raw.shape == (num_vars * num_nl, num_t)
 
         data_dict = {}
         for var_idx, name in dataset_dict.items():
             data_dict[name] = np.zeros(self.shape, dtype=self.dtype)
-            data_dict[name][:,:] = data_raw[num_nl*var_idx:num_nl*(var_idx+1),:]
-        
+            data_dict[name][:, :] = data_raw[
+                num_nl * var_idx : num_nl * (var_idx + 1), :
+            ]
+
         # Pressure
         self.pressure = data_dict["pl"] + data_dict["pl_bar"]
 

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -604,7 +604,15 @@ def smoothstep3(x, down, up):
     s = 35 * x**4 + x**5 * (-84 + x * (70 + x * (-20)))
 
     # Enforce the extremal values to be 0 and 1
-    s[x < 0] = 0
-    s[x > 1] = 1
+    try:
+        # Array case
+        s[x < 0] = 0
+        s[x > 1] = 1
+    except:
+        # Scalar case
+        if x < 0:
+            s = 0
+        elif x > 1:
+            s = 1
 
     return s


### PR DESCRIPTION
This is an update on #3, which added code to include the contribution of trapped neutrinos to an EOS table. That code was too simplistic: it assumed that the $$Y_q$$ (equivalently, $$Y_l$$) is equal to $$Y_e$$ even in the presence of neutrinos, which is not correct. The new $$Y_e$$ must be computed solving:

$$Y_q = Y_e + Y_{\nu_e} - Y_{\bar{\nu}_e}$$

given $$Y_q$$. This pull request introduces a function `add_trapped_neutrinos` which does exactly that, and then adds the contribution of the trapped neutrinos to the various thermodynamics potentials using the function introduced in #3 (now renamed `add_equilibrium_neutrinos`).

The new code, as the old one, is mostly thanks to Stefano Caldini (@scaldini453).

Furthermore, the whole code has been formatted using the `black` utility.