### PR TITLE
Fixed issues with eos.py

### DIFF
--- a/compose/eos.py
+++ b/compose/eos.py
@@ -423,11 +423,11 @@ class Table:
         """
 
         if self.shape[0] > 1 and self.shape[1] > 1 and self.shape[2] > 1:
-            if not (nb_new):
+            if nb_new is None:
                 nb_new = self.nb
-            if not (yq_new):
+            if yq_new is None:
                 yq_new = self.yq
-            if not (t_new):
+            if t_new is None:
                 t_new = self.t
 
             return self.interpolate_3D(nb_new, yq_new, t_new, method=method)


### PR DESCRIPTION
**Error in interpolate() in eos.py on lines 426, 428, and 430**

It seems that before running the interpolation, interpolate() checks if non-default arrays for number densities (nb), charge fractions (yq), and temperatures (t) are used by checking if they are falsy (ex. if not nb_new:). While this would work for empty python List objects, multi-element Numpy arrays have undefined truthfullness, and if passed into interpolate(), cause errors. Explanation below.

If no arrays are passed into interpolate(), the None value specified as the default for interpolate()'s nb_new, yq_new, and t_new attributes is used. When this is checked in the "if not <value>" statements on the affected lines, it returns True (since None is falsy), and these attributes are set to the Table instance's defaults (which are located in the Table class's constructor). However, if a non-default, multi-element array is used, the "if not <value>" statement returns a ValueError. Since multi-element numpy arrays have undefined truthfulness (neither truthy nor falsy), the logic in lines 426, 428, and 430 breaks down, as undefined truthiness cannot be compared to truthy or falsy.

I fixed this by checking if each array was the None object, which is falsy (and is the default value in interpolate()'s arguments) like so (lines 426-431):

if nb_new is None:
nb_new = self.nb
if yq_new is None:
yq_new = self.yq
if t_new is None:
t_new = self.t