### PR TITLE
Add make_NQT_version to Table class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ compose/__pycache__
 compose/_version.py
 compose/NQTs/build
 compose/NQTs/__pycache__
+compose/NQTLib.cpy*
 examples/SFHo
 build
 .eggs

--- a/compose/NQTs/NQTLib.py
+++ b/compose/NQTs/NQTLib.py
@@ -7,11 +7,12 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 libfile_glob = glob.glob(os.path.join(script_dir, "..", "NQTLib*.so"))
 
 if len(libfile_glob) == 0:
-    print("Could not find library file NQTLib*.so.")
-    print(
-        "Library can be build by running 'python setup.py build' in path/to/PyCompOSE/compose/"
-    )
-    assert len(libfile_glob) > 0
+    if __name__=="__main__":
+        print("Could not find library file NQTLib*.so.")
+        print(
+            "Library can be build by running 'python setup.py build' in path/to/PyCompOSE/"
+        )
+    raise FileNotFoundError
 libfile = libfile_glob[0]
 NQT_lib = ctypes.CDLL(libfile)
 

--- a/compose/eos.py
+++ b/compose/eos.py
@@ -32,6 +32,13 @@ try:
 except ImportError:
     version = "unknown"
 
+try:
+    from .NQTs import NQTLib
+except FileNotFoundError:
+    NQTs_available = False
+else:
+    NQTs_available = True
+
 
 class Metadata:
     """
@@ -1700,6 +1707,121 @@ class Table:
 
         self.thermo["Q1"] += th_p / self.nb[:, None, None]
         self.thermo["Q7"] += th_eps + deps
+
+    def make_NQT_version(self, method="linear", NQT_order=2, use_bithacks=True):
+        """
+        Create a new version of the eos table with NQT spacing for nb and T.
+
+        Number of samples in nb and T are kept the same, as are min,max(nb) and min,max(T).
+        Note, this is written specifically for 3D tables. 
+        It is also reccommended to compute cs2 on the log table before converting to NQT. 
+        """
+        assert NQTs_available, "NQTLib could not be found. See instructions for building NQT library."
+
+        # Switching for different NQT forms
+        if NQT_order == 1 and use_bithacks:
+            NQT_exp = NQTLib.NQT_exp2_O1 
+            NQT_log = NQTLib.NQT_log2_O1
+        elif NQT_order == 2 and use_bithacks:
+            NQT_exp = NQTLib.NQT_exp2_O2
+            NQT_log = NQTLib.NQT_log2_O2
+        if NQT_order == 1 and not use_bithacks:
+            NQT_exp = NQTLib.NQT_exp2_ldexp_O1
+            NQT_log = NQTLib.NQT_log2_frexp_O1
+        elif NQT_order == 2 and not use_bithacks:
+            NQT_exp = NQTLib.NQT_exp2_ldexp_O2
+            NQT_log = NQTLib.NQT_log2_frexp_O2
+
+        # Copy table metadata
+        eos = Table(self.md, self.dtype)
+        eos.shape = deepcopy(self.shape)
+        eos.valid = self.valid.copy()
+        eos.mn = self.mn
+        eos.mp = self.mp
+        eos.lepton = self.lepton
+
+        eos.yq = self.yq.copy()
+
+        nb_min = self.nb[0]
+        nb_max = self.nb[-1]
+
+        lnb_min = NQT_log(nb_min)
+        lnb_max = NQT_log(nb_max)
+        lnb = np.linspace(lnb_min, lnb_max, num=self.shape[0])
+
+        T_min = self.t[0]
+        T_max = self.t[-1]
+
+        lT_min = NQT_log(T_min)
+        lT_max = NQT_log(T_max)
+        lT = np.linspace(lT_min, lT_max, num=self.shape[2])
+
+        eos.nb = NQT_exp(lnb)
+        eos.t = NQT_exp(lT)
+
+        lnb_in = np.log(self.nb)
+        lT_in = np.log(self.t)
+
+        lnb_out = np.log(eos.nb)
+        lT_out = np.log(eos.t)
+
+        # Sometimes the repeated logging and exping can shift the 
+        # numbers slightly out of range
+        lnb_out[0], lnb_out[-1] = lnb_in[0], lnb_in[-1]
+        lT_out[0], lT_out[-1] = lT_in[0], lT_in[-1]
+
+        lnb_grid_out, lT_grid_out = np.meshgrid(lnb_out,lT_out,indexing="ij")
+
+        xi = np.column_stack((lnb_grid_out.flatten(), lT_grid_out.flatten()))
+
+        # Since yq does not change we can save ourselves some headaches by interpolating one yq slice at a time
+        from scipy.interpolate import RegularGridInterpolator
+        def interp_by_slice(data, log=False):
+            data_new = np.zeros(eos.shape)
+
+            myvar = data[:,:,:]
+            if log:
+                myvar = np.log(myvar)
+            
+            for yq_idx in range(eos.shape[1]):
+                func = RegularGridInterpolator(
+                    (lnb_in, lT_in), myvar[:,yq_idx,:], method=method)
+                res = func(xi).reshape((eos.shape[0],eos.shape[2]))
+
+                if log:
+                    res = np.exp(res)
+                
+                data_new[:,yq_idx,:] = res
+            
+            return data_new
+
+
+        for key, data in self.thermo.items():
+            # We interpolate cs2 in logspace, and for Q1 and Q7 we 
+            # interpolate (log) pressure and energy respectively then 
+            # calculate Q1 and Q7 from those
+            if key == "Q1":
+                press_old = data*self.nb[:,np.newaxis,np.newaxis]
+                press_new = interp_by_slice(press_old, log=True)
+                eos.thermo[key] = press_new/eos.nb[:,np.newaxis,np.newaxis]
+            elif key == "Q7":
+                energy_old = (1+data)*self.nb[:,np.newaxis,np.newaxis]*self.mn
+                energy_new = interp_by_slice(energy_old, log=True)
+                eos.thermo[key] = (energy_new/(eos.nb[:,np.newaxis,np.newaxis]*eos.mn)) - 1
+            elif key == "cs2":
+                eos.thermo[key] = interp_by_slice(data,log=True)
+            else:
+                eos.thermo[key] = interp_by_slice(data)
+        for key, data in self.Y.items():
+            eos.Y[key] = interp_by_slice(data)
+        for key, data in self.A.items():
+            eos.A[key] = interp_by_slice(data)
+        for key, data in self.Z.items():
+            eos.Z[key] = interp_by_slice(data)
+        for key, data in self.qK.items():
+            eos.qK[key] = interp_by_slice(data)
+
+        return eos
 
     def _write_data(self, dfile, dtype):
         dfile.attrs["version"] = self.version

--- a/compose/eos.py
+++ b/compose/eos.py
@@ -32,14 +32,6 @@ try:
 except ImportError:
     version = "unknown"
 
-try:
-    from .NQTs import NQTLib
-except FileNotFoundError:
-    NQTs_available = False
-else:
-    NQTs_available = True
-
-
 class Metadata:
     """
     Class encoding the metadata/indexing used to read the EOS table
@@ -1716,6 +1708,13 @@ class Table:
         Note, this is written specifically for 3D tables. 
         It is also reccommended to compute cs2 on the log table before converting to NQT. 
         """
+        try:
+            from .NQTs import NQTLib
+        except FileNotFoundError:
+            NQTs_available = False
+        else:
+            NQTs_available = True
+
         assert NQTs_available, "NQTLib could not be found. See instructions for building NQT library."
 
         # Switching for different NQT forms

--- a/compose/eos.py
+++ b/compose/eos.py
@@ -1732,15 +1732,8 @@ class Table:
             NQT_exp = NQTLib.NQT_exp2_ldexp_O2
             NQT_log = NQTLib.NQT_log2_frexp_O2
 
-        # Copy table metadata
-        eos = Table(self.md, self.dtype)
-        eos.shape = deepcopy(self.shape)
-        eos.valid = self.valid.copy()
-        eos.mn = self.mn
-        eos.mp = self.mp
-        eos.lepton = self.lepton
-
-        eos.yq = self.yq.copy()
+        # Copy table metadata, N.B. also copies self.nb, self.yq, self.t
+        eos = self.copy(copy_data=False)
 
         nb_min = self.nb[0]
         nb_max = self.nb[-1]
@@ -1756,6 +1749,7 @@ class Table:
         lT_max = NQT_log(T_max)
         lT = np.linspace(lT_min, lT_max, num=self.shape[2])
 
+        # Overwrite copied eos.nb, eos.t
         eos.nb = NQT_exp(lnb)
         eos.t = NQT_exp(lT)
 

--- a/compose/eos.py
+++ b/compose/eos.py
@@ -282,7 +282,7 @@ class Table:
         dQdt[..., -1] = (Q[..., -1] - Q[..., -2]) / (log_t[0, 0, -1] - log_t[0, 0, -2])
         return dQdt / self.t[np.newaxis, np.newaxis, :]
 
-    def eval_given_rtx(self, var, nb, yq, t):
+    def eval_given_rtx(self, var, nb, yq, t, method="linear"):
         """
         Interpolates a given thermodynamic variable at the wanted locations
 
@@ -299,7 +299,7 @@ class Table:
 
         my_lnb = np.log(self.nb)
         my_lt = np.log(self.t)
-        func = RegularGridInterpolator((my_lnb, self.yq, my_lt), var)
+        func = RegularGridInterpolator((my_lnb, self.yq, my_lt), var, method=method)
 
         xi = np.column_stack((np.log(nb).flatten(), yq.flatten(), np.log(t).flatten()))
         out = func(xi).reshape(nb.shape)

--- a/examples/SFHo_NQT.py
+++ b/examples/SFHo_NQT.py
@@ -1,22 +1,69 @@
-# This example shows how to create an NQT table from an extant .h5
+# PyCompOSE: manages CompOSE tables
+# Copyright (C) 2022, David Radice <david.radice@psu.edu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This example shows how to import/export CompOSE tables using the NQT logs
 #
 # Instructions
-# - Run the 'SFHo.py' example to obtain 'SFHo.h5'
-# - Run the command 'python setup.py build' in the folder
-#    ../compose/NQTs to build the NQT library
-# - Run this script to produce 'SFHo_NQT.h5'
+# - Create a folder "SFHo" at the same location as this script
+# - Download https://compose.obspm.fr/eos/34 and place it in a folder "SFHo"
+# - Run the script
+
+# %%
+import h5py
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+import numpy as np
 
 import os
 SCRIPTDIR = os.path.dirname(os.path.realpath(__file__))
 
 import sys
 sys.path.append(os.path.join(SCRIPTDIR, os.pardir))
-from compose.utils import convert_to_NQTs
+from compose.eos import Metadata, Table
 
-input_table_fname  = "SFHo.h5"
-output_table_fname = "SFHo_NQT.h5"
+# %%
+md = Metadata(
+    pairs = {
+        0: ("e", "electron"),
+        10: ("n", "neutro"),
+        11: ("p", "proton"),
+        4002: ("He4", "alpha particle"),
+        3002: ("He3", "helium 3"),
+        3001: ("H3", "tritium"),
+        2001: ("H2", "deuteron")
+    },
+    quads = {
+        999: ("N", "average nucleous")
+    }
+)
+eos = Table(md)
+eos.read(os.path.join(SCRIPTDIR, "SFHo"))
 
-input_table_loc  = os.path.join(SCRIPTDIR, "SFHo", input_table_fname)
-output_table_loc = os.path.join(SCRIPTDIR, "SFHo", output_table_fname)
+# %%
+eos.compute_cs2(floor=1e-6)
+eos.compute_abar()
+eos.validate()
+# Remove the highest temperature point
+eos.restrict_idx(it1=-1)
+eos.shrink_to_valid_nb()
 
-convert_to_NQTs(input_table_loc, output_table_loc, NQT_order=2, use_bithacks=True)
+# %%
+eos.write_hdf5(os.path.join(SCRIPTDIR, "SFHo", "SFHo.h5"))
+eos.write_athtab(os.path.join(SCRIPTDIR, "SFHo", "SFHo.athtab"))
+
+eos_NQT = eos.make_NQT_version()
+eos_NQT.write_hdf5(os.path.join(SCRIPTDIR, "SFHo", "SFHo_NQT.h5"))
+eos_NQT.write_athtab(os.path.join(SCRIPTDIR, "SFHo", "SFHo_NQT.athtab"))


### PR DESCRIPTION
`make_NQT_version()` creates a new Table object from the current one with nb and T resampled onto an NQT-equally spaced log grid. All other data in the object is copied/reinterpolated as necessary. Squared sound speed is interpolated in log space to circumvent possibly going negative. Pressure and energy are interpolated in log space, and Q1 and Q7 recalculated from these. All other variables are interpolated in normal-space.